### PR TITLE
Feat: Ease deployment with volttron-docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 
 cratedb-raw/
+volttron1-volume/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "volttron-docker"]
+	path = volttron-docker
+	url = https://github.com/VOLTTRON/volttron-docker.git

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Sample implementation of a **Smart IoT Room** that elevates the capabilities of 
 - Open APIs for Data Retrieval
 - Open APIs for Device Control
 - Monitoring Dashboard
+- Ease Deployment with Docker
 
 
 ## 💻 Images
@@ -28,13 +29,28 @@ Sample implementation of a **Smart IoT Room** that elevates the capabilities of 
 
 ## ⚙️ Setting up
 
-1. Download the repo using `git clone https://github.com/thakorneyp11/volttron-iot-demo.git` in your terminal or directly from github page in zip format.
+```bash
+# clone this repository with submodules
+git clone --recursive https://github.com/thakorneyp11/volttron-iot-demo.git
 
-2. To start Volttron platform:
-```
-source ~/volttron/env/bin/activate
-volttron-ctl shutdown --platform  # if Volttron session already starts
-volttron --bind-web-address http://0.0.0.0:8000 -vv -l ~/volttron/volttron.log&
+# or if you already cloned the repository, here's how to get the submodules
+git submodule update --init --recursive
+
+# change directory to project
+cd volttron-iot-demo
+
+# creates Volttron container with ZMQ message bus
+# along with Grafana and CrateDB containers
+docker-compose up -d
+
+# to ssh into Volttron container
+docker exec -itu volttron volttron1 bash
+
+# setup an Agent: install, configure, enable, and start
+vctl install /home/volttron/workspace/Agents/RESTAgent --tag rest_agent --vip-identity rest_agent
+vctl config store rest_agent /home/volttron/workspace/Agents/RESTAgent/config
+vctl enable --tag rest_agent
+vctl start --tag rest_agent
 ```
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,15 +20,32 @@ services:
     networks:
       - internal
 
-  grafana:
-    image: grafana/grafana-oss:latest
-    container_name: "grafana"
+  # grafana:
+  #   image: grafana/grafana-oss:latest
+  #   container_name: "grafana"
+  #   ports:
+  #     - "3000:3000"
+  #   restart: unless-stopped
+  #   user: '1000'
+  #   environment:
+  #     - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource
+  #   networks:
+  #     - internal
+
+  volttron1:
+    container_name: volttron1
+    hostname: volttron1
+    image: eclipsevolttron/volttron:v3.0
     ports:
-      - "3000:3000"
-    restart: unless-stopped
-    user: '1000'
+      - 8443:8443  # http port for volttron central and binded web address
+    volumes:
+      - ./volttron_setup/platform_config.yml:/platform_config.yml  # platform config for Volttron
+      - ./volttron-docker/configs:/home/volttron/configs  # configs for agents (default directory)
+      - ./volttron1-volume:/home/volttron/db  # volttron db (default directory)
+      - ./:/home/volttron/workspace  # our workspace for developing agents
     environment:
-      - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource
+      - CONFIG=/home/volttron/configs
+      - LOCAL_USER_ID=1000
     networks:
       - internal
 

--- a/integration_testing/cratedb_create_table.py
+++ b/integration_testing/cratedb_create_table.py
@@ -3,7 +3,8 @@
 
 from crate import client
 
-HOST = "localhost"
+HOST = "cratedb-raw"  # run script in volttron container: docker-compose service name
+# HOST = "localhost"  # run script in local machine
 PORT = 4200
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy==1.25.2
-opencv-python==4.8.0.76
+crate==0.34.0
+numpy==1.21.6
+opencv-python==4.8.1.78
 pendulum==2.1.2
-requests==2.31.0
+requests==2.23.0

--- a/volttron_setup/Dockerfile-dev
+++ b/volttron_setup/Dockerfile-dev
@@ -1,0 +1,132 @@
+# Dockerfile for building a Volttron development image
+
+# source: https://github.com/VOLTTRON/volttron-docker
+# source: https://hub.docker.com/r/eclipsevolttron/volttron (eclipsevolttron/volttron:v3.0)
+
+ARG image_user=amd64
+ARG image_repo=debian
+ARG image_tag=buster
+
+FROM ${image_user}/${image_repo}:${image_tag} as volttron_base
+
+SHELL [ "bash", "-c" ]
+
+ENV OS_TYPE=debian
+ENV DIST=buster
+ENV VOLTTRON_GIT_BRANCH=rabbitmq-volttron
+ENV VOLTTRON_USER_HOME=/home/volttron
+ENV VOLTTRON_HOME=${VOLTTRON_USER_HOME}/.volttron
+ENV CODE_ROOT=/code
+ENV VOLTTRON_ROOT=${CODE_ROOT}/volttron
+ENV VOLTTRON_USER=volttron
+ENV USER_PIP_BIN=${VOLTTRON_USER_HOME}/.local/bin
+ENV RMQ_ROOT=${VOLTTRON_USER_HOME}/rabbitmq_server
+ENV RMQ_HOME=${RMQ_ROOT}/rabbitmq_server-3.7.7
+
+USER root
+
+RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
+    procps \
+    gosu \
+    vim \
+    tree \
+    build-essential \
+    python3-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
+    openssl \
+    libssl-dev \
+    libevent-dev \
+    git \
+    gnupg \
+    dirmngr \
+    apt-transport-https \
+    wget \
+    curl \
+    ca-certificates \
+    libffi-dev \
+    sqlite3
+
+# Set default 'python' to 'python3'
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+# Set default 'pip' to 'pip3'
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
+
+# Create a user called 'volttron'
+RUN id -u $VOLTTRON_USER &>/dev/null || adduser --disabled-password --gecos "" $VOLTTRON_USER
+
+RUN mkdir -p /code && chown $VOLTTRON_USER.$VOLTTRON_USER /code && \
+    echo "export PATH=/home/volttron/.local/bin:$PATH" > /home/volttron/.bashrc
+
+############################################
+# ENDING volttron_base stage
+# Creating volttron_core stage
+############################################
+FROM volttron_base AS volttron_core
+
+# copy over /core, i.e. the custom startup scripts for this image
+RUN mkdir /startup $VOLTTRON_HOME && \
+    chown $VOLTTRON_USER.$VOLTTRON_USER $VOLTTRON_HOME
+COPY ./volttron-docker/core /startup
+RUN chmod +x /startup/*
+
+# copy over volttron repo
+USER $VOLTTRON_USER
+COPY --chown=volttron:volttron ./volttron-docker/volttron /code/volttron
+WORKDIR /code/volttron
+
+# for running on MacOS
+RUN python3 -m pip install --upgrade pip
+RUN pip install pip setuptools wheel Cython==3.0.0a10  # source: https://github.com/gevent/gevent/issues/1801
+RUN pip install gevent==20.9.0 --no-build-isolation
+
+RUN pip install -e . --user --extra-index-url https://www.piwheels.org/simple
+RUN echo "package installed at `date`"
+
+############################################
+# RABBITMQ SPECIFIC INSTALLATION
+############################################
+# the ARG install_rmq must be declared twice due to scope; see https://docs.docker.com/engine/reference/builder/#using-arg-variables
+USER root
+ARG install_rmq
+RUN if [ "${install_rmq}" = "false" ] ; then \
+      echo "Not installing RMQ dependencies.";  \
+    else \
+      ./scripts/rabbit_dependencies.sh $OS_TYPE $DIST && \
+      python -m pip install gevent-pika --extra-index-url https://www.piwheels.org/simple; \
+    fi
+
+USER $VOLTTRON_USER
+ARG install_rmq
+RUN if [ "${install_rmq}" = "false" ] ; then \
+      echo "Not installing RMQ"; \
+    else \
+      mkdir $RMQ_ROOT && \
+      set -eux && \
+      wget -P $VOLTTRON_USER_HOME https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.7.7/rabbitmq-server-generic-unix-3.7.7.tar.xz && \
+      tar -xf $VOLTTRON_USER_HOME/rabbitmq-server-generic-unix-3.7.7.tar.xz --directory $RMQ_ROOT && \
+      $RMQ_HOME/sbin/rabbitmq-plugins enable rabbitmq_management rabbitmq_federation rabbitmq_federation_management rabbitmq_shovel rabbitmq_shovel_management rabbitmq_auth_mechanism_ssl rabbitmq_trust_store;  \
+    fi
+
+############################################
+# Install pip dependencies
+############################################
+COPY ./requirements.txt /requirements.txt
+
+RUN python3 -m pip install --upgrade pip
+RUN pip3 install -r /requirements.txt
+
+
+########################################
+# The following lines should be run from any Dockerfile that
+# is inheriting from this one as this will make the volttron
+# run in the proper location.
+#
+# The user must be root at this point to allow gosu to work
+########################################
+# USER root
+# WORKDIR ${VOLTTRON_USER_HOME}
+# ENTRYPOINT ["/startup/entrypoint.sh"]
+# CMD ["/startup/bootstart.sh"]

--- a/volttron_setup/platform_config.yml
+++ b/volttron_setup/platform_config.yml
@@ -1,0 +1,70 @@
+# Properties to be added to the root config file
+# the properties should be ingestible for volttron
+# the values will be presented in the config file
+# as key=value
+config:
+  vip-address: tcp://0.0.0.0:22916
+  # For rabbitmq this should match the hostname specified in
+  # in the docker compose file hostname field for the service.
+  bind-web-address: https://0.0.0.0:8443
+  volttron-central-address: https://0.0.0.0:8443
+  instance-name: volttron1
+  message-bus: zmq # allowed values: zmq, rmq
+  # volttron-central-serverkey: a different key
+
+# Agents dictionary to install. The key must be a valid
+# identity for the agent to be installed correctly.
+agents:
+
+  # Each agent identity.config file should be in the configs
+  # directory and will be used to install the agent.
+  listener:
+    source: $VOLTTRON_ROOT/examples/ListenerAgent
+    config: $CONFIG/listener.config
+    tag: listener
+
+  platform.driver:
+    source: $VOLTTRON_ROOT/services/core/PlatformDriverAgent
+    config_store:
+      fake.csv:
+        file: $VOLTTRON_ROOT/examples/configurations/drivers/fake.csv
+        type: --csv
+      devices/fake-campus/fake-building/fake-device:
+        file: $VOLTTRON_ROOT/examples/configurations/drivers/fake.config
+    tag: driver
+
+  # TLDR: If you want to install a Volttron Central Platform agent, you must first install the
+  # Platform Driver before installing VCP agent
+  # Additional: VolttronCentralPlatform requires Bacpypes, which gets installed only when Platform Driver is installed.
+  # This is an unfortunate and not ideal setup, however, this issue will be addresed in a later PR so that VCP Agent
+  # can be installed on its own without having to install Platform Driver first.
+  platform.agent:
+    source: $VOLTTRON_ROOT/services/core/VolttronCentralPlatform
+    config: $CONFIG/vcp.config
+    tag: vcp
+
+  platform.actuator:
+    source: $VOLTTRON_ROOT/services/core/ActuatorAgent
+    tag: actuator
+
+  platform.historian:
+    source: $VOLTTRON_ROOT/services/core/SQLHistorian
+    config: $CONFIG/historian.config
+    tag: historian
+
+  volttron.central:
+    source: $VOLTTRON_ROOT/services/core/VolttronCentral
+    config: $CONFIG/vc.config
+    tag: vc
+
+#  weather:
+#    source: $VOLTTRON_ROOT/examples/DataPublisher
+#    config: $CONFIG/weather.config
+
+#  price:
+#    source: $VOLTTRON_ROOT/examples/DataPublisher
+#    config: $CONFIG/price.config
+
+#  platform.bacnet_proxy:
+#    source: $VOLTTRON_ROOT/services/core/BACnetProxy
+#    config: $CONFIG/bacnet-proxy.json


### PR DESCRIPTION
## Tasks
- Setup method to easily deploy Volttron using Docker
- Allowing developer to access and develop Volttron agents within the Docker container

## Latest setup method
- run these bash commands

```bash
# clone this repository with submodules
git clone --recursive https://github.com/thakorneyp11/volttron-iot-demo.git

# or if you already cloned the repository, here's how to get the submodules
git submodule update --init --recursive

# change directory to project
cd volttron-iot-demo

# creates Volttron container with ZMQ message bus
# along with Grafana and CrateDB containers
docker-compose up -d

# to ssh into Volttron container
docker exec -itu volttron volttron1 bash

# to setup an Agent: install, configure, enable, and start
vctl install /home/volttron/workspace/Agents/RESTAgent --tag rest_agent --vip-identity rest_agent
vctl config store rest_agent /home/volttron/workspace/Agents/RESTAgent/config
vctl enable --tag rest_agent
vctl start --tag rest_agent
```

## Testing Results
- can currently run volttron commands `vctl` on MacOS using docker container

![Screenshot 2566-11-30 at 00 40 55](https://github.com/thakorneyp11/volttron-iot-demo/assets/58812639/3a325701-671c-4e39-a95c-c81aa42f47cf)

- connecting Volttron agents to CrateDB database ([reference: integration_testing/cratedb_create_table.py](https://github.com/thakorneyp11/volttron-iot-demo/blob/master/integration_testing/cratedb_create_table.py))
  - can use `http://cratedb-raw:4200` to access within `internal` docker network

## Future Improvement
- `volttron1` container still took 5-10 minutes to bootup Volttron platform (bottle-neck on `setup-platform.py` script)
- restarting the container using `docker restart volttron1` still lead to error on redundant `web-ssl-cert`
  - workaround: recreate the docker container again (took 5-10 minutes)

## Resource
- https://github.com/VOLTTRON/volttron-docker
- https://hub.docker.com/r/eclipsevolttron/volttron (eclipsevolttron/volttron:v3.0)